### PR TITLE
[RELEASE] 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
-    <img src="https://github.com/txitxo0/congatudo-add-on/blob/main/images/logo.svg?raw=true" width="800" alt="congatudo">
+    <img src="https://github.com/freeconga/congatudo-add-on/blob/main/images/logo.svg?raw=true" width="800" alt="congatudo">
     <p align="center"><h2>Free your Conga from the cloud</h2></p>
 </div>
 
 Congatudo add-on aims to be an easy way to install Valetudo Conga fork in a home assistant server, being a vendor-agnostic abstraction and cloud replacement for vacuum robots inluding Cecotec Conga robots.
 
-For more information, check out the [repository](https://github.com/adrigzr/Valetudo)
+For more information, check out the [repository](https://github.com/freeconga/Congatudo)
 
 ### Installation
 
@@ -38,8 +38,8 @@ Now you need to connect your robot to your add-on.
 
 ### Screenshots
 
-![image](https://github.com/txitxo0/congatudo-add-on/blob/main/images/MainMenu.png?raw=true)
-![image](https://github.com/txitxo0/congatudo-add-on/blob/main/images/map.png?raw=true)
+![image](https://github.com/freeconga/congatudo-add-on/blob/main/images/MainMenu.png?raw=true)
+![image](https://github.com/freeconga/congatudo-add-on/blob/main/images/map.png?raw=true)
 
 [//]: # (### Join the Discussion)
 
@@ -49,6 +49,6 @@ Now you need to connect your robot to your add-on.
 ### Resources
 
 * [FreeConga project](https://gitlab.com/freeconga) - Projects under develop for Cecotec Conga vacuum
-* [Valetudo for Conga Fork](https://github.com/adrigzr/Valetudo)
+* [Valetudo for Conga Fork](https://github.com/freeconga/Congatudo)
 * [Lovelace Valetudo Map Card](https://github.com/TheLastProject/lovelace-valetudo-map-card) - Map card for Home Assistant
 * [I can't believe it's not Valetudo](https://github.com/Hypfer/ICantBelieveItsNotValetudo) - A companion service for PNG Maps

--- a/congatudo-beta/CHANGELOG.md
+++ b/congatudo-beta/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.5 - 2022-10-21
+
+### Changed
+- Update base image to [Valetudo 2022.09.0](https://github.com/Hypfer/Valetudo/releases/tag/2022.09.0)
+
+### Removed
+- Section old frontend.
+- `presets` from zones and `locations`
+
 ## 0.2.4
 
 - Update base image to [Valetudo 2022.02.0](https://github.com/Hypfer/Valetudo/releases/tag/2022.02.0)

--- a/congatudo-beta/Dockerfile
+++ b/congatudo-beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM adrigzr/valetudo-conga:homeassistant-2022.02.0-conga.0
+FROM ghcr.io/freeconga/congatudo:homeassistant-2022.09.0-conga.0
 
 # Change user to root
 USER root

--- a/congatudo-beta/README.md
+++ b/congatudo-beta/README.md
@@ -1,10 +1,10 @@
 <div align="center">
-    <img src="https://github.com/txitxo0/congatudo-add-on/blob/main/images/logo.svg?raw=true" width="800" alt="valetudo">
+    <img src="https://github.com/freeconga/congatudo-add-on/blob/main/images/logo.svg?raw=true" width="800" alt="valetudo">
     <p align="center"><h2>Free your vacuum from the cloud</h2></p>
 </div>
 
-Congatudo add-on aims to be a vendor-agnostic abstraction and cloud replacement for Cecotec Conga vacuum robots based on [Valetudo for Conga fork](https://github.com/adrigzr/Valetudo)
+Congatudo add-on aims to be a vendor-agnostic abstraction and cloud replacement for Cecotec Conga vacuum robots based on [Valetudo for Conga fork](https://github.com/freeconga/Congatudo)
 
 ### Instructions
 
-See the [README on GitHub](https://github.com/txitxo0/congatudo-add-on) for all the details.
+See the [README on GitHub](https://github.com/freeconga/congatudo-add-on) for all the details.

--- a/congatudo-beta/config.yml
+++ b/congatudo-beta/config.yml
@@ -1,5 +1,5 @@
 name: Congatudo (beta)
-version: 0.2.4-beta.0
+version: 0.2.5-beta.0
 slug: congatudo_beta
 description: Free your vacuum from the cloud
 url: https://github.com/freeconga/congatudo-add-on

--- a/congatudo/README.md
+++ b/congatudo/README.md
@@ -1,10 +1,10 @@
 <div align="center">
-    <img src="https://github.com/txitxo0/congatudo-add-on/blob/main/images/logo.svg?raw=true" width="800" alt="valetudo">
+    <img src="https://github.com/freeconga/congatudo-add-on/blob/main/images/logo.svg?raw=true" width="800" alt="valetudo">
     <p align="center"><h2>Free your vacuum from the cloud</h2></p>
 </div>
 
-Congatudo add-on aims to be a vendor-agnostic abstraction and cloud replacement for Cecotec Conga vacuum robots based on [Valetudo for Conga fork](https://github.com/adrigzr/Valetudo)
+Congatudo add-on aims to be a vendor-agnostic abstraction and cloud replacement for Cecotec Conga vacuum robots based on [Valetudo for Conga fork](https://github.com/freeconga/Congatudo)
 
 ### Instructions
 
-See the [README on GitHub](https://github.com/txitxo0/congatudo-add-on) for all the details.
+See the [README on GitHub](https://github.com/freeconga/congatudo-add-on) for all the details.


### PR DESCRIPTION
- He actualizado las referencias url a repositorios viejos
- He actualizado la versión Beta para que utilice la imagen ghcr.io/freeconga/congatudo:homeassistant-2022.09.0-conga.0